### PR TITLE
Update cldera-tools path to /projects/sctr/cldera-tools

### DIFF
--- a/cime_config/machines/cmake_macros/intel_boca.cmake
+++ b/cime_config/machines/cmake_macros/intel_boca.cmake
@@ -1,5 +1,5 @@
 set(ALBANY_PATH "/projects/ccsm/AlbanyTrilinos_20190904/albany-build/install")
-set(CLDERA_PATH "/projects/cldera/cldera-tools/install-master/intel/")
+set(CLDERA_PATH "/projects/sctr/cldera-tools/cldera-tools-install")
 if (COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_SLASHPROC")
 endif()

--- a/cime_config/machines/cmake_macros/intel_flight.cmake
+++ b/cime_config/machines/cmake_macros/intel_flight.cmake
@@ -1,5 +1,5 @@
 set(ALBANY_PATH "/projects/ccsm/AlbanyTrilinos_20190904/albany-build/install")
-set(CLDERA_PATH "/projects/cldera/cldera-tools/install-master/intel/")
+set(CLDERA_PATH "/projects/sctr/cldera-tools/cldera-tools-install")
 if (COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_SLASHPROC")
 endif()


### PR DESCRIPTION
Previously our builds pointed to the cldera project directory, but now we use the sctr project directory. This is necessary now that the cldera-tools version we use no longer matches the version for cldera.